### PR TITLE
Fixing TS  project refs.

### DIFF
--- a/apps/webpart1/fast-serve/webpack.extend.js
+++ b/apps/webpart1/fast-serve/webpack.extend.js
@@ -15,6 +15,18 @@ const transformConfig = function (initialWebpackConfig) {
   // transform the initial webpack config here, i.e.
   // initialWebpackConfig.plugins.push(new webpack.Plugin()); etc.
 
+  initialWebpackConfig.plugins.forEach(plugin => {
+    if(plugin.constructor.name === 'ForkTsCheckerWebpackPlugin') {
+      //console.log(plugin);
+      plugin.options.typescript = {
+        build: true
+      }
+    }
+  });
+
+  const tsRuleOptions = initialWebpackConfig.module.rules[0].use[0].options;
+  tsRuleOptions.projectReferences = true;
+
   return initialWebpackConfig;
 }
 


### PR DESCRIPTION
I think I made some progress regarding this issue (at least I think so :)). 

The idea is just to set [projectreferences=true](https://github.com/TypeStrong/ts-loader#projectreferences) for `ts-loader` and [build=true](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/6.5.x#typescript-options) and `fork-ts-checker-webpack-plugin`. With these two changes it works for me. 

 Could you test this fix with your another repository? If it's ok, we will add it to the fast-serve core.